### PR TITLE
fix init

### DIFF
--- a/lib/NovaPoshta/bootstrap.php
+++ b/lib/NovaPoshta/bootstrap.php
@@ -4,6 +4,6 @@ include_once 'Core/autoload.php';
 
 if (!defined('NOVA_POSHTA_PATH_SDK')) {
     define('NOVA_POSHTA_PATH_SDK', dirname(__FILE__) . '/');
-
-    \NovaPoshta\Core\Autoload::init();
 }
+
+\NovaPoshta\Core\Autoload::init();


### PR DESCRIPTION
Не нашёл больше условий объявления в коде NOVA_POSHTA_PATH_SDK, так что видимо проверяется на возможность собственного объявление, но тогда init никогда не запуститься.
